### PR TITLE
Support NaN for per-stream attenuation/rolloff/volumeThreshold

### DIFF
--- a/Sources/HiFiSpatialAudio/classes/HiFiAudioAPIData.swift
+++ b/Sources/HiFiSpatialAudio/classes/HiFiAudioAPIData.swift
@@ -113,10 +113,11 @@ public class HiFiAudioAPIData {
     */
     public var orientationEuler: OrientationEuler3D?
     /**
-        The volume threshold associated with a user. Units are decibels. The scale of this value is the same as that of `ReceivedHiFiAudioAPIData.volumeDecibels`.
+        The volume threshold associated with a user. A volume level below this value is considered background noise and will be smoothly gated off. The floating point value is specified in dBFS (decibels relative to full scale) with values between -96 dB (indicating no gating) and 0 dB (effectively muting the input from this user). By default, there is a global volume threshold (set for a given space), of -40 dB, which applies to all users in a space.
 
-        A volume level below this value is considered background noise and will be smoothly gated off.
-        The floating point value is specified in dBFS (decibels relative to full scale) with values between -96 dB (indicating no gating) and 0 dB (effectively muting the input from this user).
+        Setting this value to `NaN` will cause the volume threshold from the space to be used instead.
+     
+        If you don't supply a `volumeThreshold` when constructing instantiations of this class, the previous value of `volumeThreshold` will be used. If `volumeThreshold` has never been supplied, the volume threshold of the space will be used instead.
     */
     public var volumeThreshold: Float?
     /**
@@ -131,19 +132,17 @@ public class HiFiAudioAPIData {
     */
     public var hiFiGain: Float?
     /**
-        This value affects how far a user's sound will travel in 3D space, without affecting the user's loudness.
-        By default, there is a global attenuation value (set for a given space) that applies to all users in a space. This default space attenuation is usually 0.5, which represents a reasonable approximation of a real-world fall-off in sound over distance.
+        This value affects how far a user's sound will travel in 3D space, without affecting the user's loudness. By default, there is a global attenuation value of 0.5 (set for a given space) that applies to all users in a space. This default represents a reasonable approximation of a real-world fall-off in sound over distance.
         
         Lower numbers represent less attenuation (i.e. sound travels farther); higher numbers represent more attenuation (i.e. sound drops off more quickly).
         
         When setting this value for an individual user, the following holds:
      
-        - Positive numbers should be between 0 and 1, and they represent a logarithmic attenuation. This range is recommended, as sounds more natural.
-        - Smaller numbers represent less attenuation, so a number such as `0.2` can be used to make a particular user's audio travel farther than other users', for instance in "amplified" concert type settings. Similarly, an extremely small non-zero number (e.g. `0.00001`) can be used to effectively turn off attenuation for a given user within a reasonably sized space, resulting in a "broadcast mode" where the user can be heard throughout most of the space regardless of their location relative to other users.
-            - Note: The actual value `0` is used internally to represent the default; for setting minimal attenuation, use small non-zero numbers instead. See also `userRolloff` below.
-        - Negative attenuation numbers are used to represent linear attenuation, and are a somewhat artificial, non-real-world concept. However, this setting can be used as a blunt tool to easily test attenuation, and tune it aggressively in extreme circumstances. When using linear attenuation, the setting is the distance in meters at which the audio becomes totally inaudible.
+        - A value of `NaN` causes the user to inherit the global attenuation for a space, or, if zones are defined for the space, the attenuation settings at the user's position. **COMPATIBILITY WARNING:** Currently, setting `userAttenuation` to 0 will also reset its value to the space/zone default attenuation. In the future, the value of `userAttenuation` will only be reset if it is set to `NaN`. A `userAttenuation` set to 0 will in the future be treated as a "broadcast mode", making the user audible throughout the entire space. If your spatial audio client application is currently resetting `userAttenuation` by setting it to 0, please change it to set `userAttenuation` to `NaN` instead, in order for it to continue working with future versions of High Fidelity's Spatial Audio API.
+        - Positive numbers between 0 and 1 result in logarithmic attenuation of the user. This range is recommended, as it sounds more natural. Smaller positive numbers represent less attenuation. A number such as `0.2` will make a particular user's audio travel farther than other users', suitable for "amplified" concert settings. Similarly, a very small non-zero number (e.g. `0.00001`), for a reasonably sized space, results in a "broadcast mode", where the user can be heard throughout most of the space regardless of their location relative to other users.
+        - Negative numbers result in linear attenuation of the user. Linear attenuation is a somewhat artificial, non-real-world concept. However, it can be used as a blunt tool to easily test attenuation, and tune it aggressively in extreme circumstances. When using linear attenuation, the setting is the distance in meters at which the audio becomes totally inaudible. For example, with a `userAttenuation` of `-12.0`, the user's audio becomes inaudible to other users at 12 meters away.
         
-        If you don't supply an `userAttenuation` when constructing instantiations of this class, `userAttenuation` will be `nil` and the default will be used.
+        If you don't supply a `userAttenuation` when constructing instantiations of this class, the previous value of `userAttenuation` will be used. If `userAttenuation` has never been supplied, the attenuation of the space will be used instead, or, if zone attenuations are defined for a space, the attenuation according to the user's location in the space.
         
         ✔ The client sends `userAttenuation` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
         
@@ -151,12 +150,16 @@ public class HiFiAudioAPIData {
      */
     public var userAttenuation: Float?
     /**
-        This value represents the progressive high frequency roll-off in meters, a measure of how the higher frequencies in a user's sound are dampened as the user gets further away. By default, there is a global roll-off value (set for a given space), currently 16 meters, which applies to all users in a space. This value represents the distance for a 1kHz rolloff. Values in the range of 12 to 32 meters provide a more "enclosed" sound, in which high frequencies tend to be dampened over distance as they are in the real world.
+        This value represents the progressive high frequency roll-off in meters, a measure of how the higher frequencies in a user's sound are dampened as the user gets further away. By default, there is a global roll-off value (set for a given space), of 16 meters, which applies to all users in a space. This value represents the distance for a 1kHz rolloff. Values in the range of 12 to 32 meters provide a more "enclosed" sound, in which high frequencies tend to be dampened over distance as they are in the real world.
         
         Generally, you should change roll-off values for the entire space rather than for individual users, but
         extremely high values (e.g. `99999`) may be used in combination with "broadcast mode"-style `userAttenuation` settings to cause the broadcasted voice to sound crisp and "up close" even at very large distances.
+     
+        A `userRolloff` of `NaN` will cause the user to inherit the global frequency rolloff for the space, or, if zones are defined for the space, the frequency rolloff settings at the user's position.
+     
+        **COMPATIBILITY WARNING:** Currently, setting `userRolloff` to 0 will also reset its value to the space/zone default rolloff. In the future, the value of `userRolloff` will only be reset if it is set to `NaN`. A `userRolloff` set to 0 will in the future be treated as a valid frequency rolloff value, which will cause the user's sound to become muffled over a short distance. If your spatial audio client application is currently resetting `userRolloff` by setting it to 0, please change it to set `userRolloff` to `NaN` instead, in order for it to continue working with future versions of High Fidelity's Spatial Audio API.
         
-        If you don't supply an `userRolloff` when constructing instantiations of this class, `userRolloff` will be `nil`.
+        If you don't supply a `userRolloff` when constructing instantiations of this class, the previous value of `userRolloff` will be used. If `userRolloff` has never been supplied, the frequency rolloff of the space will be used instead, or, if zone attenuations are defined for a space, the rolloff according to the user's location in the space.
         
         ✔ The client sends `userRolloff` data to the server when `_transmitHiFiAudioAPIDataToServer()` is called.
         

--- a/Sources/HiFiSpatialAudio/classes/HiFiAudioAPIData.swift
+++ b/Sources/HiFiSpatialAudio/classes/HiFiAudioAPIData.swift
@@ -171,6 +171,22 @@ public class HiFiAudioAPIData {
         Internally, this variable is used to keep track of which other user gain changes need to be sent to the server. The keys are hashed visit IDs, and the values have units of `HiFiGain`.
     */
     public var _otherUserGainQueue: [String : Int]?
+    /**
+        This is an internal class and it is not recommended for normal usage of the API.
+        
+        See instead `HiFiAudioAPIData.position`, which allows you to set the position for a client.
+        
+        Internally, this variable is used to keep track of when the client's position has changed and needs to be sent to the server.
+    */
+    public var _transformedPosition: Point3D?
+    /**
+        This is an internal class and it is not recommended for normal usage of the API.
+        
+        See instead `HiFiAudioAPIData.orientationQuat`, which allows you to set the orientation for a client.
+        
+        Internally, this variable is used to keep track of when the client's orientation has changed and needs to be sent to the server.
+    */
+    public var _transformedOrientationQuat: OrientationQuat3D?
     
     public init(
         position: Point3D? = nil,

--- a/Sources/HiFiSpatialAudio/classes/HiFiCommunicator.swift
+++ b/Sources/HiFiSpatialAudio/classes/HiFiCommunicator.swift
@@ -378,6 +378,15 @@ public class HiFiCommunicator {
             self._lastTransmittedHiFiAudioAPIData.position!.y = dataJustTransmitted.position!.y
             self._lastTransmittedHiFiAudioAPIData.position!.z = dataJustTransmitted.position!.z
         }
+        if (dataJustTransmitted._transformedPosition != nil) {
+            if (self._lastTransmittedHiFiAudioAPIData._transformedPosition == nil) {
+                self._lastTransmittedHiFiAudioAPIData._transformedPosition = Point3D()
+            }
+            
+            self._lastTransmittedHiFiAudioAPIData._transformedPosition!.x = dataJustTransmitted._transformedPosition!.x
+            self._lastTransmittedHiFiAudioAPIData._transformedPosition!.y = dataJustTransmitted._transformedPosition!.y
+            self._lastTransmittedHiFiAudioAPIData._transformedPosition!.z = dataJustTransmitted._transformedPosition!.z
+        }
         
         if (dataJustTransmitted.orientationQuat != nil) {
             if (self._lastTransmittedHiFiAudioAPIData.orientationQuat == nil) {
@@ -388,6 +397,16 @@ public class HiFiCommunicator {
             self._lastTransmittedHiFiAudioAPIData.orientationQuat!.x = dataJustTransmitted.orientationQuat!.x
             self._lastTransmittedHiFiAudioAPIData.orientationQuat!.y = dataJustTransmitted.orientationQuat!.y
             self._lastTransmittedHiFiAudioAPIData.orientationQuat!.z = dataJustTransmitted.orientationQuat!.z
+        }
+        if (dataJustTransmitted._transformedOrientationQuat != nil) {
+            if (self._lastTransmittedHiFiAudioAPIData._transformedOrientationQuat == nil) {
+                self._lastTransmittedHiFiAudioAPIData._transformedOrientationQuat = OrientationQuat3D()
+            }
+            
+            self._lastTransmittedHiFiAudioAPIData._transformedOrientationQuat!.w = dataJustTransmitted._transformedOrientationQuat!.w
+            self._lastTransmittedHiFiAudioAPIData._transformedOrientationQuat!.x = dataJustTransmitted._transformedOrientationQuat!.x
+            self._lastTransmittedHiFiAudioAPIData._transformedOrientationQuat!.y = dataJustTransmitted._transformedOrientationQuat!.y
+            self._lastTransmittedHiFiAudioAPIData._transformedOrientationQuat!.z = dataJustTransmitted._transformedOrientationQuat!.z
         }
         
         if (dataJustTransmitted.volumeThreshold != nil) {

--- a/Sources/HiFiSpatialAudio/classes/HiFiCommunicator.swift
+++ b/Sources/HiFiSpatialAudio/classes/HiFiCommunicator.swift
@@ -186,11 +186,10 @@ public class HiFiCommunicator {
         
         To generate a JWT for use with the High Fidelity Audio API:
 
-        1. Head to https://jwt.io/ to find the appropriate library for your langauge.
-            a. For Swift applications, we recommend <https://github.com/vapor/jwt-kit|JWTKit>.
-        2. Using the <https://account.highfidelity.com/dev/account|High Fidelity Audio API Developer Console>,
+        1. Head to https://jwt.io/ to find the appropriate library for your langauge. For Swift applications, we recommend [JWTKit](https://github.com/vapor/jwt-kit).
+        2. Using the [High Fidelity Audio API Developer Console](https://account.highfidelity.com/dev/account)
         obtain your App ID, Space ID, and App Secret.
-        3. Create your user's JWT using the appropriate library, passing your App ID, Space ID, and App Secret. Please reference our <https://www.highfidelity.com/api/guides/misc/getAJWT|"Get a JWT" guide> for additional context.
+        3. Create your user's JWT using the appropriate library, passing your App ID, Space ID, and App Secret. Please reference our ["Get a JWT" guide](https://www.highfidelity.com/api/guides/misc/getAJWT) for additional context.
         4. Pass the created JWT to `connectToHiFiAudioAPIServer()`.
         
         - Parameter signalingHostURL: A URL that will be used to create a valid WebRTC signaling address at High Fidelity. The passed `signalingHostURL` parameter should not contain the protocol

--- a/Sources/HiFiSpatialAudio/classes/HiFiMixerSession.swift
+++ b/Sources/HiFiSpatialAudio/classes/HiFiMixerSession.swift
@@ -628,110 +628,142 @@ internal class HiFiMixerSession {
         var dataModified: Bool = false
         
         if (currentHiFiAudioAPIData.position != nil) {
-            var changedComponents = ["x": false, "y": false, "z": false, "changed": false]
+            var anyChanged = false
             if (previousHiFiAudioAPIData != nil && previousHiFiAudioAPIData!.position != nil) {
-                if (currentHiFiAudioAPIData.position!.x != previousHiFiAudioAPIData!.position!.x) {
-                    changedComponents["x"] = true
-                    changedComponents["changed"] = true
-                }
-                if (currentHiFiAudioAPIData.position!.y != previousHiFiAudioAPIData!.position!.y) {
-                    changedComponents["y"] = true
-                    changedComponents["changed"] = true
-                }
-                if (currentHiFiAudioAPIData.position!.z != previousHiFiAudioAPIData!.position!.z) {
-                    changedComponents["z"] = true
-                    changedComponents["changed"] = true
+                if (currentHiFiAudioAPIData.position!.x != previousHiFiAudioAPIData!.position!.x ||
+                    currentHiFiAudioAPIData.position!.y != previousHiFiAudioAPIData!.position!.y ||
+                    currentHiFiAudioAPIData.position!.z != previousHiFiAudioAPIData!.position!.z) {
+                    anyChanged = true
                 }
             } else {
-                changedComponents["x"] = true
-                changedComponents["y"] = true
-                changedComponents["z"] = true
-                changedComponents["changed"] = true
+                anyChanged = true
             }
             
-            if (changedComponents["changed"] == true) {
-                let translatedPosition = HiFiAxisConfiguration.translatePoint3DToMixerSpace(axisConfiguration: ourHiFiAxisConfiguration, inputPoint3D: currentHiFiAudioAPIData.position!)
+            if (anyChanged) {
+                var xChanged = false
+                var yChanged = false
+                var zChanged = false
+                currentHiFiAudioAPIData._transformedPosition = HiFiAxisConfiguration.translatePoint3DToMixerSpace(axisConfiguration: ourHiFiAxisConfiguration, inputPoint3D: currentHiFiAudioAPIData.position!)
+                if (previousHiFiAudioAPIData != nil && previousHiFiAudioAPIData!._transformedPosition != nil) {
+                    if (currentHiFiAudioAPIData._transformedPosition!.x != previousHiFiAudioAPIData!._transformedPosition!.x) {
+                        xChanged = true
+                    }
+                    if (currentHiFiAudioAPIData._transformedPosition!.y != previousHiFiAudioAPIData!._transformedPosition!.y) {
+                        yChanged = true
+                    }
+                    if (currentHiFiAudioAPIData._transformedPosition!.z != previousHiFiAudioAPIData!._transformedPosition!.z) {
+                        zChanged = true
+                    }
+                } else {
+                    xChanged = true
+                    yChanged = true
+                    zChanged = true
+                }
                 
-                if (changedComponents["x"] == true) {
-                    dataForMixer.x = round(translatedPosition.x * 1000)
+                if (xChanged && currentHiFiAudioAPIData._transformedPosition!.x.isFinite) {
+                    dataForMixer.x = round(currentHiFiAudioAPIData._transformedPosition!.x * 1000)
                     dataModified = true
                 }
-                if (changedComponents["y"] == true) {
-                    dataForMixer.y = round(translatedPosition.y * 1000)
+                if (yChanged && currentHiFiAudioAPIData._transformedPosition!.y.isFinite) {
+                    dataForMixer.y = round(currentHiFiAudioAPIData._transformedPosition!.y * 1000)
                     dataModified = true
                 }
-                if (changedComponents["z"] == true) {
-                    dataForMixer.z = round(translatedPosition.z * 1000)
+                if (zChanged && currentHiFiAudioAPIData._transformedPosition!.z.isFinite) {
+                    dataForMixer.z = round(currentHiFiAudioAPIData._transformedPosition!.z * 1000)
                     dataModified = true
                 }
             }
         }
         
         if (currentHiFiAudioAPIData.orientationQuat != nil) {
-            var changedComponents = ["w":false, "x": false, "y": false, "z": false, "changed": false]
+            var anyChanged = false
             if (previousHiFiAudioAPIData != nil && previousHiFiAudioAPIData!.orientationQuat != nil) {
-                if (currentHiFiAudioAPIData.orientationQuat!.w != previousHiFiAudioAPIData?.orientationQuat!.w) {
-                    changedComponents["w"] = true
-                    changedComponents["changed"] = true
-                }
-                if (currentHiFiAudioAPIData.orientationQuat!.x != previousHiFiAudioAPIData?.orientationQuat!.x) {
-                    changedComponents["x"] = true
-                    changedComponents["changed"] = true
-                }
-                if (currentHiFiAudioAPIData.orientationQuat!.y != previousHiFiAudioAPIData?.orientationQuat!.y) {
-                    changedComponents["y"] = true
-                    changedComponents["changed"] = true
-                }
-                if (currentHiFiAudioAPIData.orientationQuat!.z != previousHiFiAudioAPIData?.orientationQuat!.z) {
-                    changedComponents["z"] = true
-                    changedComponents["changed"] = true
+                if (currentHiFiAudioAPIData.orientationQuat!.w != previousHiFiAudioAPIData?.orientationQuat!.w ||
+                    currentHiFiAudioAPIData.orientationQuat!.x != previousHiFiAudioAPIData?.orientationQuat!.x ||
+                    currentHiFiAudioAPIData.orientationQuat!.y != previousHiFiAudioAPIData?.orientationQuat!.y ||
+                    currentHiFiAudioAPIData.orientationQuat!.z != previousHiFiAudioAPIData?.orientationQuat!.z) {
+                    anyChanged = true
                 }
             } else {
-                changedComponents["w"] = true
-                changedComponents["x"] = true
-                changedComponents["y"] = true
-                changedComponents["z"] = true
-                changedComponents["changed"] = true
+                anyChanged = true
             }
             
-            if (changedComponents["changed"] == true) {
-                let translatedOrientation = HiFiAxisConfiguration.translateOrientationQuat3DToMixerSpace(axisConfiguration: ourHiFiAxisConfiguration, inputOrientationQuat3D: currentHiFiAudioAPIData.orientationQuat!)
+            if (anyChanged) {
+                var wChanged = false
+                var xChanged = false
+                var yChanged = false
+                var zChanged = false
+                currentHiFiAudioAPIData._transformedOrientationQuat = HiFiAxisConfiguration.translateOrientationQuat3DToMixerSpace(axisConfiguration: ourHiFiAxisConfiguration, inputOrientationQuat3D: currentHiFiAudioAPIData.orientationQuat!)
+                if (previousHiFiAudioAPIData != nil && previousHiFiAudioAPIData!._transformedOrientationQuat != nil) {
+                    if (currentHiFiAudioAPIData._transformedOrientationQuat!.w != previousHiFiAudioAPIData!._transformedOrientationQuat!.w) {
+                        wChanged = true;
+                    }
+                    if (currentHiFiAudioAPIData._transformedOrientationQuat!.x != previousHiFiAudioAPIData!._transformedOrientationQuat!.x) {
+                        xChanged = true;
+                    }
+                    if (currentHiFiAudioAPIData._transformedOrientationQuat!.y != previousHiFiAudioAPIData!._transformedOrientationQuat!.y) {
+                        yChanged = true;
+                    }
+                    if (currentHiFiAudioAPIData._transformedOrientationQuat!.z != previousHiFiAudioAPIData!._transformedOrientationQuat!.z) {
+                        zChanged = true;
+                    }
+                } else {
+                    wChanged = true
+                    xChanged = true
+                    yChanged = true
+                    zChanged = true
+                }
                 
-                if (changedComponents["w"] == true) {
-                    dataForMixer.W = translatedOrientation.w * 1000
-                    dataModified = true
+                if (wChanged && currentHiFiAudioAPIData._transformedOrientationQuat!.w.isFinite) {
+                    dataForMixer.W = currentHiFiAudioAPIData._transformedOrientationQuat!.w * 1000
                 }
-                if (changedComponents["x"] == true) {
-                    dataForMixer.X = translatedOrientation.x * 1000
-                    dataModified = true
+                if (xChanged && currentHiFiAudioAPIData._transformedOrientationQuat!.x.isFinite) {
+                    dataForMixer.X = currentHiFiAudioAPIData._transformedOrientationQuat!.x * 1000
                 }
-                if (changedComponents["y"] == true) {
-                    dataForMixer.Y = translatedOrientation.y * 1000
-                    dataModified = true
+                if (yChanged && currentHiFiAudioAPIData._transformedOrientationQuat!.y.isFinite) {
+                    dataForMixer.Y = currentHiFiAudioAPIData._transformedOrientationQuat!.y * 1000
                 }
-                if (changedComponents["z"] == true) {
-                    dataForMixer.Z = translatedOrientation.z * 1000
-                    dataModified = true
+                if (zChanged && currentHiFiAudioAPIData._transformedOrientationQuat!.z.isFinite) {
+                    dataForMixer.Z = currentHiFiAudioAPIData._transformedOrientationQuat!.z * 1000
                 }
+                dataModified = true
             }
         }
         
-        if (currentHiFiAudioAPIData.volumeThreshold != nil) {
+        if (currentHiFiAudioAPIData.volumeThreshold != nil &&
+            !currentHiFiAudioAPIData.volumeThreshold!.isInfinite &&
+            (previousHiFiAudioAPIData == nil ||
+                 previousHiFiAudioAPIData!.volumeThreshold == nil ||
+                 currentHiFiAudioAPIData.volumeThreshold != previousHiFiAudioAPIData!.volumeThreshold ||
+                 currentHiFiAudioAPIData.volumeThreshold!.isNaN != previousHiFiAudioAPIData!.volumeThreshold!.isNaN)) {
             dataForMixer.T = currentHiFiAudioAPIData.volumeThreshold!
             dataModified = true
         }
         
-        if (currentHiFiAudioAPIData.hiFiGain != nil) {
+        if (currentHiFiAudioAPIData.hiFiGain != nil &&
+            currentHiFiAudioAPIData.hiFiGain!.isFinite &&
+            (previousHiFiAudioAPIData == nil ||
+                currentHiFiAudioAPIData.hiFiGain != previousHiFiAudioAPIData!.hiFiGain)) {
             dataForMixer.g = currentHiFiAudioAPIData.hiFiGain!
             dataModified = true
         }
         
-        if (currentHiFiAudioAPIData.userAttenuation != nil) {
+        if (currentHiFiAudioAPIData.userAttenuation != nil &&
+            !currentHiFiAudioAPIData.userAttenuation!.isInfinite &&
+            (previousHiFiAudioAPIData == nil ||
+                 previousHiFiAudioAPIData!.userAttenuation == nil ||
+                 currentHiFiAudioAPIData.userAttenuation != previousHiFiAudioAPIData!.userAttenuation ||
+                 currentHiFiAudioAPIData.userAttenuation!.isNaN != previousHiFiAudioAPIData!.userAttenuation!.isNaN)) {
             dataForMixer.a = currentHiFiAudioAPIData.userAttenuation!
             dataModified = true
         }
         
-        if (currentHiFiAudioAPIData.userRolloff != nil) {
+        if (currentHiFiAudioAPIData.userRolloff != nil &&
+            !currentHiFiAudioAPIData.userRolloff!.isInfinite &&
+            (previousHiFiAudioAPIData == nil ||
+                previousHiFiAudioAPIData!.userRolloff == nil ||
+                currentHiFiAudioAPIData.userRolloff != previousHiFiAudioAPIData!.userRolloff ||
+                currentHiFiAudioAPIData.userRolloff!.isNaN != previousHiFiAudioAPIData!.userRolloff!.isNaN)) {
             if (currentHiFiAudioAPIData.userRolloff!.isNaN) {
                 dataForMixer.r = currentHiFiAudioAPIData.userRolloff!
             } else {


### PR DESCRIPTION
While we're at it, reject non-finite floats for other user data, and calculate partial diffs for positions/quaternions in a way that should take into account coordinate transforms. (Note: coordinate transforms are not implemented yet in the Swift API)

Also, update the Swift documentation to reflect the current server behavior of treating user attenuation/user rolloff of 0 as unset.